### PR TITLE
added example of how the starweb dynamicPriceHandler method should be…

### DIFF
--- a/helloretail-starweb-dynamic-price-handler.md
+++ b/helloretail-starweb-dynamic-price-handler.md
@@ -42,11 +42,14 @@ function starwebHelloRetailPriceHandler_{{ key }}(selector){
 ```
 ```js
 on: {
-      slideChange: function (e) {
+        slideChange: function (e) {
         setTimeout(function(){
-          starwebHelloRetailPriceHandler_{{ key }}("#{{ key }} .hr-starweb-prices");
+            starwebHelloRetailPriceHandler_{{ key }}("#{{ key }} .hr-starweb-prices");
         },200);
-      },
+        },
+        afterInit: function() {
+            starwebHelloRetailPriceHandler_{{ key }}("#{{ key }} .hr-starweb-prices");
+        }
     },
 ```
 


### PR DESCRIPTION
… invoked on the afterInit event in Recommendations. This is necessary because the onSlide event won't trigger if the recommendation loads with too few products to utilize the slider functionality.